### PR TITLE
#1 .gitignore can't be a link anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
-tab-utils/_gitignore
+# jetbrains IDE settings
+.idea
+
+# Installed modules
+/node_modules/
+
+# Goldpage build
+.build/
+
+# Yarn/Npm debug info
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
https://github.com/brillout/timer-tab/issues/14